### PR TITLE
IVYPORTAL-14577: Change Portal version to SNAPSHOT

### DIFF
--- a/axonivy-express/pom.xml
+++ b/axonivy-express/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.portal</groupId>
   <artifactId>axonivy-express</artifactId>
@@ -13,7 +14,7 @@
     <dependency>
       <groupId>com.axonivy.portal</groupId>
       <artifactId>portal</artifactId>
-      <version>11.2.0-m245</version>
+      <version>9.1.0.0-SNAPSHOT</version>
       <type>iar</type>
     </dependency>
   </dependencies>

--- a/axonivy-express/processes/Functional Processes/executePredefinedWorkflow.p.json
+++ b/axonivy-express/processes/Functional Processes/executePredefinedWorkflow.p.json
@@ -37,8 +37,7 @@
           "id" : "U21-g0",
           "type" : "EmbeddedStart",
           "visual" : {
-            "at" : { "x" : 288, "y" : 64 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 288, "y" : 64 }
           },
           "parentConnector" : "f3",
           "connect" : [
@@ -48,8 +47,7 @@
           "id" : "U21-g1",
           "type" : "EmbeddedEnd",
           "visual" : {
-            "at" : { "x" : 288, "y" : 1248 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 288, "y" : 1248 }
           },
           "parentConnector" : "f6"
         }, {
@@ -707,7 +705,6 @@
           "name" : "in 1",
           "visual" : {
             "at" : { "x" : 264, "y" : 32 },
-            "size" : { "width" : 26, "height" : 26 },
             "labelOffset" : { "x" : 35, "y" : 29 }
           },
           "parentConnector" : "f30",
@@ -720,7 +717,6 @@
           "name" : "out 1",
           "visual" : {
             "at" : { "x" : 640, "y" : 416 },
-            "size" : { "width" : 26, "height" : 26 },
             "labelOffset" : { "x" : -6, "y" : 38 }
           },
           "parentConnector" : "f10"
@@ -728,8 +724,7 @@
           "id" : "S11-g2",
           "type" : "EmbeddedStart",
           "visual" : {
-            "at" : { "x" : 64, "y" : 320 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 64, "y" : 320 }
           },
           "parentConnector" : "f18",
           "connect" : [
@@ -815,8 +810,7 @@
           "id" : "S40-g0",
           "type" : "EmbeddedStart",
           "visual" : {
-            "at" : { "x" : 64, "y" : 192 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 64, "y" : 192 }
           },
           "parentConnector" : "f13",
           "connect" : [
@@ -826,8 +820,7 @@
           "id" : "S40-g1",
           "type" : "EmbeddedEnd",
           "visual" : {
-            "at" : { "x" : 544, "y" : 192 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 544, "y" : 192 }
           },
           "parentConnector" : "f4"
         }, {
@@ -939,9 +932,9 @@
                 "import java.util.Map;",
                 "import ch.ivy.addon.portalkit.enums.PortalLibrary;",
                 "import java.util.Arrays;",
-                "import ch.ivy.addon.portalkit.service.IvyAdapterService;",
+                "import com.axonivy.portal.components.service.IvyAdapterService;",
                 "",
-                "Map x = IvyAdapterService.startSubProcess(\"handleEndPage()\", null, Arrays.asList(PortalLibrary.AXON_EXPRESS.getValue()));",
+                "Map x = IvyAdapterService.startSubProcessInApplication(\"handleEndPage()\", null);",
                 "String callbackUrl = x.get(\"callbackUrl\") as String;",
                 "ivy.task.customFields().stringField(CustomFields.EXPRESS_END_PAGE_URL.toString()).set(callbackUrl);"
               ]
@@ -1000,7 +993,6 @@
           "name" : "in 1",
           "visual" : {
             "at" : { "x" : 64, "y" : 192 },
-            "size" : { "width" : 26, "height" : 26 },
             "labelOffset" : { "x" : 18, "y" : 25 }
           },
           "parentConnector" : "f8",
@@ -1013,7 +1005,6 @@
           "name" : "out 1",
           "visual" : {
             "at" : { "x" : 1200, "y" : 192 },
-            "size" : { "width" : 26, "height" : 26 },
             "labelOffset" : { "x" : 21, "y" : 25 }
           },
           "parentConnector" : "f25"
@@ -1090,8 +1081,7 @@
           "id" : "U20-g0",
           "type" : "EmbeddedStart",
           "visual" : {
-            "at" : { "x" : 320, "y" : 64 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 320, "y" : 64 }
           },
           "parentConnector" : "f15",
           "connect" : [
@@ -1101,8 +1091,7 @@
           "id" : "U20-g1",
           "type" : "EmbeddedEnd",
           "visual" : {
-            "at" : { "x" : 320, "y" : 1024 },
-            "size" : { "width" : 26, "height" : 26 }
+            "at" : { "x" : 320, "y" : 1024 }
           },
           "parentConnector" : "f17"
         }, {


### PR DESCRIPTION
Hi @nqhoan-axonivy @phhung-axonivy Please help me review this PR.

- Update latest code to make Express is compatible with the latest code of the Portal
- Change Portal verson to SNAPSHOT that make our jenskin build job works. The Portal version will be update to a fix version when we release a version of the Express to the Ivy Market. Our jenskin job: http://10.123.1.216:8080/job/axonivy-express/job/master/

Thank you!