### PR TITLE
undo: leading-edge portal version injection

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v3
-    with:
-      mvnArgs: '-Dportal.version=11.4.0-m261'


### PR DESCRIPTION
- we can not use dynamic properties when stating IAR dependencies, or the design-time support will be degraded.